### PR TITLE
feat(services): list page + dynamic route + section layout

### DIFF
--- a/src/app/services/[id]/not-found.tsx
+++ b/src/app/services/[id]/not-found.tsx
@@ -1,0 +1,12 @@
+// src/app/services/[id]/not-found.tsx
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div style={{ maxWidth: 800, margin: "2rem auto" }}>
+      <h1>Servicio no encontrado</h1>
+      <p>El recurso solicitado no existe.</p>
+      <Link href="/services">← Volver a servicios</Link>
+    </div>
+  );
+}

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -1,0 +1,31 @@
+// src/app/services/[id]/page.tsx
+import { notFound } from "next/navigation";
+import { getService, services } from "../../../lib/services";
+
+type Props = { params: { id: string } };
+
+// Pre-render estático de cada servicio (SSG)
+export function generateStaticParams() {
+  return services.map(s => ({ id: s.id }));
+}
+
+// Metadata por servicio
+export function generateMetadata({ params }: Props) {
+  const svc = getService(params.id);
+  return {
+    title: svc ? `${svc.name} | Servicios` : "Servicio no encontrado",
+    description: svc?.summary ?? "Detalle de servicio"
+  };
+}
+
+export default function ServiceDetail({ params }: Props) {
+  const svc = getService(params.id);
+  if (!svc) return notFound();
+
+  return (
+    <article style={{ maxWidth: 800, margin: "2rem auto" }}>
+      <h1>{svc.name}</h1>
+      <p>{svc.content}</p>
+    </article>
+  );
+}

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -2,24 +2,25 @@
 import { notFound } from "next/navigation";
 import { getService, services } from "../../../lib/services";
 
-type Props = { params: { id: string } };
+type Params = { id: string };
+type Props = { params: Promise<Params> }; // 👈 params asíncrono (Next 15)
 
-// Pre-render estático de cada servicio (SSG)
 export function generateStaticParams() {
   return services.map(s => ({ id: s.id }));
 }
 
-// Metadata por servicio
-export function generateMetadata({ params }: Props) {
-  const svc = getService(params.id);
+export async function generateMetadata({ params }: Props) {
+  const { id } = await params; // 👈 await
+  const svc = getService(id);
   return {
     title: svc ? `${svc.name} | Servicios` : "Servicio no encontrado",
-    description: svc?.summary ?? "Detalle de servicio"
+    description: svc?.summary ?? "Detalle de servicio",
   };
 }
 
-export default function ServiceDetail({ params }: Props) {
-  const svc = getService(params.id);
+export default async function ServiceDetail({ params }: Props) {
+  const { id } = await params; // 👈 await
+  const svc = getService(id);
   if (!svc) return notFound();
 
   return (

--- a/src/app/services/layout.tsx
+++ b/src/app/services/layout.tsx
@@ -1,0 +1,8 @@
+// src/app/services/layout.tsx
+export default function ServicesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <section style={{ minHeight: "50vh" }}>
+      {children}
+    </section>
+  );
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,8 +1,21 @@
-export default function AboutUs() {
+// src/app/services/page.tsx
+import Link from "next/link";
+import { services } from "../../lib/services"; // relativo desde /app/services
+
+export default function ServicesPage() {
   return (
-    <main style={{ padding: "2rem" }}>
+    <section style={{ maxWidth: 800, margin: "2rem auto" }}>
       <h1>Servicios</h1>
-      <p>Esta es la página de servicios.</p>
-    </main>
-  )
+      <ul style={{ padding: 0, listStyle: "none" }}>
+        {services.map(s => (
+          <li key={s.id} style={{ margin: "1rem 0", borderBottom: "1px solid #222", paddingBottom: "1rem" }}>
+            <h2 style={{ margin: 0 }}>
+              <Link href={`/services/${s.id}`}>{s.name}</Link>
+            </h2>
+            <p style={{ margin: "0.5rem 0 0" }}>{s.summary}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
 }

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -1,0 +1,10 @@
+// src/lib/services.ts
+export const services = [
+  { id: "web-design", name: "Web Design", summary: "Sitios rápidos y optimizados.", content: "Diseño y desarrollo con foco en performance y SEO técnico." },
+  { id: "seo",        name: "SEO",        summary: "Mejor ranking en Google.",     content: "Auditoría, on-page, estructura y contenidos por intención de búsqueda." },
+  { id: "ads",        name: "Paid Ads",   summary: "Campañas rentables.",          content: "Estrategia y optimización continua en Google Ads y Meta Ads." },
+];
+
+export function getService(id: string) {
+  return services.find(s => s.id === id);
+}


### PR DESCRIPTION
Summary

Adds services list page at /services.

Implements dynamic route /services/[id] with generateStaticParams.

Adds per-service generateMetadata (basic SEO).

Includes not-found.tsx for invalid IDs.

Creates src/app/services/layout.tsx as section layout.

Adds helper src/lib/services.ts (minimal data + getService).

How to test

Go to /services and verify titles + summaries.

Open /services/web-design, /services/seo, /services/ads.

Try an invalid ID (e.g., /services/foo) → should show section 404.

Notes

No env var changes.

No breaking changes.